### PR TITLE
Handle artifacts being in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+downloaded_artifacts

--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ steps:
 | project             | Required     | Sentry Project Name |
 | org_name            | Required     | Sentry organization slug |
 | url_prefix          |              | Override url root, see https://docs.sentry.io/platforms/javascript/sourcemaps/#using-sentry-cli |
+| strip_prefix        |              | Remove part of the url for matching purposes https://docs.sentry.io/platforms/javascript/sourcemaps/#using-sentry-cli |
+| upload_subdirectory |              | Directory to change to inside of archives, ex dist/ |
 

--- a/hooks/command
+++ b/hooks/command
@@ -31,6 +31,7 @@ trap on_failure ERR
 
 set -x
 
+mkdir -p downloaded_artifacts
 buildkite-agent artifact download "${SOURCEMAPS_ARTIFACT}" downloaded_artifacts
 
 if [ -z "$RELEASE_NAME" ]; then

--- a/hooks/command
+++ b/hooks/command
@@ -5,6 +5,7 @@ export SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN:-}
 # see https://docs.sentry.io/cli/configuration/#configuration-values
 export RELEASE_NAME=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_RELEASE_NAME:-}
 export STRIP_PREFIX=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_STRIP_PREFIX:-}
+export UPLOAD_SUBDIRECTORY=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_UPLOAD_SUBDIRECTORY:-}
 export SENTRY_AUTH_TOKEN=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_AUTH_TOKEN:-$SENTRY_AUTH_TOKEN}
 export SOURCEMAPS_ARTIFACT=$BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_SOURCEMAPS_ARTIFACT
 export SENTRY_ORG=$BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME
@@ -42,7 +43,7 @@ sentry-cli releases new "$RELEASE_NAME"
 if [ -e .git ]; then
   sentry-cli releases set-commits "$RELEASE_NAME" --auto || true
 fi
-sentry-cli releases files "$RELEASE_NAME" upload-sourcemaps "downloaded_artifacts/" "--strip-prefix=downloaded_artifacts/${STRIP_PREFIX}" "$URL_PREFIX"
+sentry-cli releases files "$RELEASE_NAME" upload-sourcemaps "downloaded_artifacts/${UPLOAD_SUBDIRECTORY}" "--strip-prefix=downloaded_artifacts/${STRIP_PREFIX}" "$URL_PREFIX"
 sentry-cli releases finalize "$RELEASE_NAME"
 
 echo "All Done"

--- a/hooks/command
+++ b/hooks/command
@@ -4,6 +4,7 @@ set -ueo pipefail
 export SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN:-}
 # see https://docs.sentry.io/cli/configuration/#configuration-values
 export RELEASE_NAME=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_RELEASE_NAME:-}
+export STRIP_PREFIX=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_STRIP_PREFIX:-}
 export SENTRY_AUTH_TOKEN=${BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_AUTH_TOKEN:-$SENTRY_AUTH_TOKEN}
 export SOURCEMAPS_ARTIFACT=$BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_SOURCEMAPS_ARTIFACT
 export SENTRY_ORG=$BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME
@@ -30,7 +31,7 @@ trap on_failure ERR
 
 set -x
 
-[ -e "${SOURCEMAPS_ARTIFACT}" ] || buildkite-agent artifact download "${SOURCEMAPS_ARTIFACT}" .
+buildkite-agent artifact download "${SOURCEMAPS_ARTIFACT}" downloaded_artifacts
 
 if [ -z "$RELEASE_NAME" ]; then
   RELEASE_NAME=$(sentry-cli releases propose-version)
@@ -40,7 +41,7 @@ sentry-cli releases new "$RELEASE_NAME"
 if [ -e .git ]; then
   sentry-cli releases set-commits "$RELEASE_NAME" --auto || true
 fi
-sentry-cli releases files "$RELEASE_NAME" upload-sourcemaps "${SOURCEMAPS_ARTIFACT}" "$URL_PREFIX"
+sentry-cli releases files "$RELEASE_NAME" upload-sourcemaps "downloaded_artifacts/" "--strip-prefix=downloaded_artifacts/${STRIP_PREFIX}" "$URL_PREFIX"
 sentry-cli releases finalize "$RELEASE_NAME"
 
 echo "All Done"

--- a/hooks/sentry-cli
+++ b/hooks/sentry-cli
@@ -14,5 +14,5 @@ docker run --rm \
   -e SENTRY_ORG \
   -e HTTP_PROXY \
   -e HTTPS_PROXY \
-  $DOCKER_REPO "$*"
+  $DOCKER_REPO "$@"
 

--- a/hooks/sentry-cli
+++ b/hooks/sentry-cli
@@ -14,5 +14,5 @@ docker run --rm \
   -e SENTRY_ORG \
   -e HTTP_PROXY \
   -e HTTPS_PROXY \
-  $DOCKER_REPO $@
+  $DOCKER_REPO "$*"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,6 +17,8 @@ configuration:
       type: string
     url_prefix:
       type: string
+    strip_prefix:
+      type: string
   required:
     - sourcemaps_artifact
     - org_name

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,6 +19,8 @@ configuration:
       type: string
     strip_prefix:
       type: string
+    upload_subdirectory:
+      type: string
   required:
     - sourcemaps_artifact
     - org_name

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: Upload Sourcemaps to Sentry
+name: sentry-sourcemaps-uploader-buildkite-plugin
 description: Upload Sourcemaps to Sentry
 author: https://github.com/risepeopleinc
 requirements:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -8,6 +8,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME="some-org"
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
 
+  stub mkdir \
+    "-p downloaded_artifacts : echo Made Directory"
+
   stub buildkite-agent \
     "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
 
@@ -21,10 +24,12 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/command"
 
   assert_success
+  assert_output --partial "Made Directory"
   assert_output --partial "Downloaded Artifacts"
   assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
 
+  unstub mkdir
   unstub buildkite-agent
   unstub sentry-cli
 }
@@ -35,6 +40,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME="some-org"
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_STRIP_PREFIX="strippie/"
+
+  stub mkdir \
+    "-p downloaded_artifacts : echo Made Directory"
 
   stub buildkite-agent \
     "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
@@ -49,10 +57,12 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/command"
 
   assert_success
+  assert_output --partial "Made Directory"
   assert_output --partial "Downloaded Artifacts"
   assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
 
+  unstub mkdir
   unstub buildkite-agent
   unstub sentry-cli
 }
@@ -62,6 +72,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_SOURCEMAPS_ARTIFACT="sourcemaps/*"
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME="some-org"
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
+
+  stub mkdir \
+    "-p downloaded_artifacts : echo Made Directory"
 
   stub buildkite-agent \
     "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
@@ -76,10 +89,12 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/command"
 
   assert_success
+  assert_output --partial "Made Directory"
   assert_output --partial "Downloaded Artifacts"
   assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
 
+  unstub mkdir
   unstub buildkite-agent
   unstub sentry-cli
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -16,15 +16,14 @@ load '/usr/local/lib/bats/load.bash'
 
   stub sentry-cli \
     "releases propose-version : echo fakeversion" \
-    "releases new fakeversion : echo" \
-    "releases set-commits fakeversion --auto : echo" \
+    "releases new fakeversion : echo new fake version" \
+    "releases set-commits fakeversion --auto : echo set-commits" \
     "releases files fakeversion upload-sourcemaps downloaded_artifacts/ --strip-prefix=downloaded_artifacts/ '' : echo Uploaded Files" \
     "releases finalize fakeversion : echo"
 
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "Made Directory"
   assert_output --partial "Downloaded Artifacts"
   assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
@@ -49,15 +48,48 @@ load '/usr/local/lib/bats/load.bash'
 
   stub sentry-cli \
     "releases propose-version : echo fakeversion" \
-    "releases new fakeversion : echo" \
-    "releases set-commits fakeversion --auto : echo" \
+    "releases new fakeversion : echo new fake version" \
+    "releases set-commits fakeversion --auto : echo set-commits" \
     "releases files fakeversion upload-sourcemaps downloaded_artifacts/ --strip-prefix=downloaded_artifacts/strippie/ '' : echo Uploaded Files" \
     "releases finalize fakeversion : echo"
 
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "Made Directory"
+  assert_output --partial "Downloaded Artifacts"
+  assert_output --partial "Uploaded Files"
+  assert_output --partial "All Done"
+
+  unstub mkdir
+  unstub buildkite-agent
+  unstub sentry-cli
+}
+
+@test "Uploads sourcemaps to buildkite - Supports upload subpath" {
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_AUTH_TOKEN="faketoken"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_SOURCEMAPS_ARTIFACT="sourcemaps/*"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME="some-org"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_STRIP_PREFIX="strippie/"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_UPLOAD_SUBDIRECTORY="upload_subpath"
+
+
+  stub mkdir \
+    "-p downloaded_artifacts : echo Made Directory"
+
+  stub buildkite-agent \
+    "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
+
+  stub sentry-cli \
+    "releases propose-version : echo fakeversion" \
+    "releases new fakeversion : echo new fake version" \
+    "releases set-commits fakeversion --auto : echo set-commits" \
+    "releases files fakeversion upload-sourcemaps downloaded_artifacts/upload_subpath --strip-prefix=downloaded_artifacts/strippie/ '' : echo Uploaded Files" \
+    "releases finalize fakeversion : echo"
+
+  run "$PWD/hooks/command"
+
+  assert_success
   assert_output --partial "Downloaded Artifacts"
   assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
@@ -81,15 +113,14 @@ load '/usr/local/lib/bats/load.bash'
 
   stub sentry-cli \
     "releases propose-version : echo fakeversion" \
-    "releases new fakeversion : echo" \
-    "releases set-commits fakeversion --auto : echo" \
+    "releases new fakeversion : echo new fake version" \
+    "releases set-commits fakeversion --auto : echo set-commits" \
     "releases files fakeversion upload-sourcemaps downloaded_artifacts/ --strip-prefix=downloaded_artifacts/ '' : echo Uploaded Files" \
     "releases finalize fakeversion : echo"
 
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "Made Directory"
   assert_output --partial "Downloaded Artifacts"
   assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -9,18 +9,48 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
 
   stub buildkite-agent \
-    "artifact download sourcemaps/* . : echo "
+    "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
 
   stub sentry-cli \
     "releases propose-version : echo fakeversion" \
     "releases new fakeversion : echo" \
     "releases set-commits fakeversion --auto : echo" \
-    "releases files fakeversion upload-sourcemaps sourcemaps/* : echo" \
+    "releases files fakeversion upload-sourcemaps downloaded_artifacts/ --strip-prefix=downloaded_artifacts/ '' : echo Uploaded Files" \
     "releases finalize fakeversion : echo"
 
   run "$PWD/hooks/command"
 
   assert_success
+  assert_output --partial "Downloaded Artifacts"
+  assert_output --partial "Uploaded Files"
+  assert_output --partial "All Done"
+
+  unstub buildkite-agent
+  unstub sentry-cli
+}
+
+@test "Uploads sourcemaps to buildkite - Supports extra strip prefix" {
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_AUTH_TOKEN="faketoken"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_SOURCEMAPS_ARTIFACT="sourcemaps/*"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_ORG_NAME="some-org"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
+  export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_STRIP_PREFIX="strippie/"
+
+  stub buildkite-agent \
+    "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
+
+  stub sentry-cli \
+    "releases propose-version : echo fakeversion" \
+    "releases new fakeversion : echo" \
+    "releases set-commits fakeversion --auto : echo" \
+    "releases files fakeversion upload-sourcemaps downloaded_artifacts/ --strip-prefix=downloaded_artifacts/strippie/ '' : echo Uploaded Files" \
+    "releases finalize fakeversion : echo"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Downloaded Artifacts"
+  assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
 
   unstub buildkite-agent
@@ -34,18 +64,20 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SENTRY_SOURCEMAPS_UPLOADER_PROJECT="some-project"
 
   stub buildkite-agent \
-    "artifact download sourcemaps/* . : echo "
+    "artifact download sourcemaps/* downloaded_artifacts : echo Downloaded Artifacts"
 
   stub sentry-cli \
     "releases propose-version : echo fakeversion" \
     "releases new fakeversion : echo" \
     "releases set-commits fakeversion --auto : echo" \
-    "releases files fakeversion upload-sourcemaps sourcemaps/* : echo" \
+    "releases files fakeversion upload-sourcemaps downloaded_artifacts/ --strip-prefix=downloaded_artifacts/ '' : echo Uploaded Files" \
     "releases finalize fakeversion : echo"
 
   run "$PWD/hooks/command"
 
   assert_success
+  assert_output --partial "Downloaded Artifacts"
+  assert_output --partial "Uploaded Files"
   assert_output --partial "All Done"
 
   unstub buildkite-agent


### PR DESCRIPTION
Previously dist/scripts/*.js would not get uploaded when you request the artifacts of dist/*

This PR changes it so 
1) literal 'dist/*' is processed by sentry uploader not bash
2) Download artifacts to a sub directory so we can just upload the entire contents requested by artifacts path

Added in the ability to supply a --strip-prefix for url matching, and uploading a subdirectory